### PR TITLE
fix:長い名前のユーザーによるUI崩れ対応

### DIFF
--- a/src/components/RoomParticipant.vue
+++ b/src/components/RoomParticipant.vue
@@ -13,7 +13,7 @@ const answer = computed(() => {
 </script>
 <template>
   <article class="w-32 flex flex-col-reverse items-center">
-    <h3 class="m-1">{{ participant.name }}</h3>
+    <h3 class="m-1 w-full truncate">{{ participant.name }}</h3>
     <!-- Audience の場合、 Room.vue からそれを示す値として -1 を送っている -->
     <div
       v-if="answer === '-1'"


### PR DESCRIPTION
## 修正内容

Your Nameを表示する領域に[truncate](https://tailwindcss.com/docs/text-overflow#truncate)クラスを付与して超過部分が省略されるようにした


修正前 | 修正後
-- | --
![修正前](https://github.com/user-attachments/assets/5d722cca-923f-4672-a7ae-7da358262f17) | ![修正後](https://github.com/user-attachments/assets/985d32d3-e9ad-412b-a4ba-048782935dfe)


</figure>

## 修正案候補

* 修正案1：文字自体を小さくする
* 修正案2：入力文字文字に制限を設ける
* 修正案3：超過文字を省略する

## 選定理由

修正案1は、本質的な長い名前のユーザー回避になってないのでNG。
修正案2は、`InputName.vue`にバリデーションを追加すれば実現できるが、使い勝手がわくるなりそうなのでNG
修正案3は、**スタイル追加するだけ＆名前が同姓同名のレアケース以外は防げそうなので採用**

修正案3を行なって名前被りがもしも発生した場合は、ツールチップで全文字表示すれば回避できる。
がそのケースが出た時に対応でいいと判断。